### PR TITLE
Add cross-linking features to Stores

### DIFF
--- a/packages/node-utils/src/constants.ts
+++ b/packages/node-utils/src/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * A Unicode invisible character which will sort strings alphabetically after
+ * any other character.
+ */
+export const INVISIBLE_CHARACTER = '‎';

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,4 +1,5 @@
 // Constants
+export * from './constants';
 export * from './stubs';
 
 // Helpers

--- a/packages/stores-core/src/Base.ts
+++ b/packages/stores-core/src/Base.ts
@@ -4,7 +4,10 @@ const abstractError = new Error(
   'Cannot invoke method of abstract store class.',
 );
 
-export abstract class Store<State extends object> {
+export abstract class Store<
+  State extends object,
+  LinkedStores extends { [x: string]: Store<any, any> } = {},
+> {
   /**
    * A static property used to determine whether this is a store declaration.
    *
@@ -73,6 +76,14 @@ export abstract class Store<State extends object> {
   protected getState<S extends State>(): S {
     throw abstractError;
   }
+
+  /**
+   * A helper which returns a reference to other stores for the purpose of
+   * linking state between stores.
+   */
+  protected get linked(): LinkedStores {
+    throw abstractError;
+  };
 
   /**
    * A helper which executes when using a `<StoreProvider />` component is
@@ -163,12 +174,12 @@ export abstract class Store<State extends object> {
 
 export interface StoreConstructor<
   StoreType extends Store<State>,
-  State extends object
+  State extends object,
 > {
   new <S extends State>(
     initialState?: Partial<S> | (() => Partial<S>),
     applyOnReset?: boolean,
-  ): StoreType & { state: S }
+  ): StoreType & { state: S };
   defaultState<S extends State>(): S;
   isStore: boolean;
 }

--- a/packages/stores-core/src/Store.ts
+++ b/packages/stores-core/src/Store.ts
@@ -88,7 +88,7 @@ export interface CreateStore<
 class StoreType<State extends object> extends Store<State> {}
 
 // Keys to be ignored when method binding.
-const ignoreList = ['constructor', '__isLocked', 'linked', 'state'];
+const ignoreList = ['constructor', 'linked', 'state'];
 
 export function define<
   StoreId extends string,
@@ -692,10 +692,6 @@ export function define<
       s[GlobalKeys.SNAPSHOTS][storeId] = createGetSnapshot(
         this as StoreInstance,
       );
-    }
-
-    protected get __isLocked() {
-      return isResourceLocked(this.$[StoreKeys.CONFIG][MetaData.STORE_ID]);
     }
 
     protected override getState<S extends State>() {

--- a/packages/stores-core/src/Store.ts
+++ b/packages/stores-core/src/Store.ts
@@ -32,6 +32,7 @@ const enum StoreKeys {
   PENDING,
   PREVIOUS,
   REGISTER,
+  SUBSCIPTIONS,
 }
 
 const enum MetaData {
@@ -55,6 +56,7 @@ interface IStore<StoreId extends string, State extends object> {
   [StoreKeys.REGISTER]: (
     listener: (store: StoreInstance<State>) => void,
   ) => () => void;
+  [StoreKeys.SUBSCIPTIONS]: Record<string, StoreInstance>;
 }
 
 interface IGlobal<
@@ -86,7 +88,7 @@ export interface CreateStore<
 class StoreType<State extends object> extends Store<State> {}
 
 // Keys to be ignored when method binding.
-const ignoreList = ['constructor', '__isLocked', 'state'];
+const ignoreList = ['constructor', '__isLocked', 'linked', 'state'];
 
 export function define<
   StoreId extends string,
@@ -135,6 +137,16 @@ export function define<
     // Return a function which ensures the removal of this registration.
     return function removeGlobalListener() {
       s[domain] = s[domain].filter((next) => next !== listener);
+    };
+  }
+
+  function addStoreLinks(
+    store: StoreInstance,
+    links: Array<[string, StoreInstance]>,
+  ) {
+    (store as $Store).$[StoreKeys.SUBSCIPTIONS] = {
+      ...(store as $Store).$[StoreKeys.SUBSCIPTIONS],
+      ...Object.fromEntries(links),
     };
   }
 
@@ -662,6 +674,7 @@ export function define<
         this,
         StoreKeys.LISTENERS,
       ) as (listener: (store: StoreInstance<State>) => void) => () => void;
+      $[StoreKeys.SUBSCIPTIONS] = {};
 
       // Then, set the internal properties within this instance.
       this.$ = $;
@@ -765,12 +778,18 @@ export function define<
       return this;
     }
 
+    public get linked() {
+      return this.$[StoreKeys.SUBSCIPTIONS];
+    }
+
     public get state() {
       return this.getState();
     }
   }
 
   return {
+    /** Internal use only. */
+    __addLinks: addStoreLinks,
     /** Internal use only. */
     __areEqual: defaults.areEqual,
     /** Internal use only. */

--- a/packages/stores-core/src/types.ts
+++ b/packages/stores-core/src/types.ts
@@ -32,10 +32,16 @@ export type Subscribe<Source> = (
 ) => () => void;
 
 /** The Typescript definition of a Store class declaration. */
-export type StoreClass<State extends object = any> = typeof Store<State>;
+export type StoreClass<
+  State extends object = any,
+  LinkedStores extends Record<string, Store<any, any>> = any,
+> = typeof Store<State, LinkedStores>;
 
 /** The Typescript definition of an instatianted Store. */
-export type StoreInstance<State extends object = any> = Store<State>;
+export type StoreInstance<
+  State extends object = any,
+  LinkedStores extends Record<string, Store<any, any>> = any,
+> = Store<State, LinkedStores>;
 
 /** A look-up object of Store instance types. */
 export type StoresType = Record<string, StoreInstance>;

--- a/packages/stores-core/src/utils.ts
+++ b/packages/stores-core/src/utils.ts
@@ -1,3 +1,4 @@
+import { INVISIBLE_CHARACTER } from '@cimanyd/node-utils';
 import type { StoreEntries, StoreInstance, StoresType } from './types';
 
 const enum Mapping {
@@ -11,6 +12,7 @@ type Descriptor<T = any> = TypedPropertyDescriptor<T> & {
   get: { (): T; isComputed?: boolean };
 };
 
+const stateLabel = `${INVISIBLE_CHARACTER}state`;
 const internalOnly = [
   '$',
   'action',
@@ -68,15 +70,15 @@ export function createGetSnapshot<Store extends StoreInstance>(store: Store) {
     const fauxStore = {
       ...(linked.length > 0
         ? {
-          linked: Object.fromEntries(
-            linked.map(([name, store]) => [
-              name,
-              Object.getPrototypeOf(store),
-            ]),
-          ),
-        }
+            '#linked': Object.fromEntries(
+              linked.map(([name, store]) => [
+                name,
+                Object.getPrototypeOf(store),
+              ]),
+            ),
+          }
         : {}),
-      state: { ...instance.state },
+      [stateLabel]: { ...instance.state },
     } as any;
 
     // Cycle through each mapping identified when the store was processed.

--- a/packages/stores-core/src/utils.ts
+++ b/packages/stores-core/src/utils.ts
@@ -19,6 +19,10 @@ const internalOnly = [
   'constructor',
   'getState',
   'linked',
+  'onMount',
+  'produce',
+  'reset',
+  'setState',
   'state',
 ];
 

--- a/packages/stores-react/src/types.ts
+++ b/packages/stores-react/src/types.ts
@@ -4,6 +4,7 @@ import type {
   StoreInstance,
   StoresType,
 } from '@cimanyd/stores';
+import type { ToInstanceName } from './utils';
 
 export type AccessTo<Source> = [() => Source, Subscribe<Source>, RunInAction];
 
@@ -80,6 +81,11 @@ export type StoreEntries<Stores extends StoresType> = Array<
     [Key in keyof Stores]: [Key, Stores[Key]];
   }[keyof Stores]
 >;
+
+export interface StoreMiddleware<StoreKey extends string> {
+  interStoreBindings?: Partial<{ [Key in StoreKey]: Array<ToInstanceName<StoreKey>> }>;
+  hookSettings?: HookSettings;
+}
 
 export type Subscribe<Source> = (
   listener: (source: Source) => void,


### PR DESCRIPTION
Adds linking to Stores, whereby one store may reference state, and call the methods of, another store which was initialized via the same initialization function. Additionally, some labelling improvements have been added to the `<StoreProvider />`. As a consequence of the change, the options passed to the initializer function is no longer hook specific options, but now a `MiddlewareOptions` property, for which `HookOptions` are now a sub-property of.

closes #3 and #4 